### PR TITLE
use url filter

### DIFF
--- a/hash.js
+++ b/hash.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const md5 = require('md5');
 
 const assets = [
-  'css/styles.css',
-  'js/scripts.js'
+  '/css/styles.css',
+  '/js/scripts.js'
 ];
 
 const dataFile = '_data/hash.json';

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -10,8 +10,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"/>
     <meta name="generator" content="Eleventy" />
 
-    <link rel="stylesheet" href="{{ hash['css/styles.css'] | url }}"/>
-    <script defer src="{{ hash['js/scripts.js'] | url }}"></script>
+    <link rel="stylesheet" href="{{ hash['/css/styles.css'] | url }}"/>
+    <script defer src="{{ hash['/js/scripts.js'] | url }}"></script>
 
     {% block head %}{% endblock %}
   </head>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -10,8 +10,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"/>
     <meta name="generator" content="Eleventy" />
 
-    <link rel="stylesheet" href="/{{ hash['css/styles.css'] }}"/>
-    <script defer src="/{{ hash['js/scripts.js'] }}"></script>
+    <link rel="stylesheet" href="{{ hash['css/styles.css'] | url }}"/>
+    <script defer src="{{ hash['js/scripts.js'] | url }}"></script>
 
     {% block head %}{% endblock %}
   </head>


### PR DESCRIPTION
For example, when someone uses the [`pathPrefix` option in the configuration](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix), assets won't get loaded because it's not respected in the `base.njk`.

[`url` filter method](https://www.11ty.dev/docs/filters/url/) should be used to create a URL that respects options such as mentioned above.

It's a minor thing but could be a stopper for newbs.